### PR TITLE
fix: allow null for keychain accessibility on Apple platforms

### DIFF
--- a/flutter_secure_storage/lib/options/apple_options.dart
+++ b/flutter_secure_storage/lib/options/apple_options.dart
@@ -27,7 +27,7 @@ abstract class AppleOptions extends Options {
   const AppleOptions({
     String? groupId,
     String? accountName = AppleOptions.defaultAccountName,
-    KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
+    KeychainAccessibility? accessibility = KeychainAccessibility.unlocked,
     bool synchronizable = false,
   })  : _groupId = groupId,
         _accessibility = accessibility,
@@ -38,14 +38,15 @@ abstract class AppleOptions extends Options {
 
   final String? _groupId;
   final String? _accountName;
-  final KeychainAccessibility _accessibility;
+  final KeychainAccessibility? _accessibility;
   final bool _synchronizable;
 
   @override
   Map<String, String> toMap() => <String, String>{
-        // TODO: Update min SDK from 2.12 to 2.15 in new major version to fix this deprecation warning
-        // ignore: deprecated_member_use
-        'accessibility': describeEnum(_accessibility),
+        if (_accessibility != null)
+          // TODO: Update min SDK from 2.12 to 2.15 in new major version to fix this deprecation warning
+          // ignore: deprecated_member_use
+          'accessibility': describeEnum(_accessibility!),
         if (_accountName != null) 'accountName': _accountName!,
         if (_groupId != null) 'groupId': _groupId!,
         'synchronizable': '$_synchronizable',

--- a/flutter_secure_storage/lib/options/ios_options.dart
+++ b/flutter_secure_storage/lib/options/ios_options.dart
@@ -5,7 +5,7 @@ class IOSOptions extends AppleOptions {
   const IOSOptions({
     String? groupId,
     String? accountName = AppleOptions.defaultAccountName,
-    KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
+    KeychainAccessibility? accessibility = KeychainAccessibility.unlocked,
     bool synchronizable = false,
   }) : super(
           groupId: groupId,

--- a/flutter_secure_storage/lib/options/macos_options.dart
+++ b/flutter_secure_storage/lib/options/macos_options.dart
@@ -5,7 +5,7 @@ class MacOsOptions extends AppleOptions {
   const MacOsOptions({
     String? groupId,
     String? accountName = AppleOptions.defaultAccountName,
-    KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
+    KeychainAccessibility? accessibility = KeychainAccessibility.unlocked,
     bool synchronizable = false,
   }) : super(
           groupId: groupId,


### PR DESCRIPTION
Allows null values for accessibility on Apple platforms